### PR TITLE
Fixes issue that removed trailing base64 padding.

### DIFF
--- a/src/main/java/br/com/ggdio/InstantorLambda.java
+++ b/src/main/java/br/com/ggdio/InstantorLambda.java
@@ -78,7 +78,7 @@ public class InstantorLambda implements RequestHandler<APIGatewayProxyRequestEve
 			
 			String[] params = body.split("&");
 			for (String paramLine : params) {
-				String[] kv = paramLine.split("=");
+				String[] kv = paramLine.split("=", 2);
 				parameters.put(kv[0], kv[1]);
 				
 			}


### PR DESCRIPTION
Hello!

I took the liberty of taking a look at your Lambda and I think that I found the issue.

The issue were a `.split` that trimmed of any padding `=` from the payload thus removing bytes from it.

Kind Regards,
David @ Instantor